### PR TITLE
Add unit tests for term storage and searcher

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,12 @@ Slash commands can be used to get current search terms, update search terms, and
 ## Tips
 
 - Replies are ephemeral by default to avoid spamming channels.
+
+## Running tests
+
+Install dependencies and run the test suite using [pytest](https://pytest.org/):
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -1,0 +1,39 @@
+import json
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def create_searcher(tmp_path, monkeypatch):
+    monkeypatch.setenv("GUILD_ID", "1")
+    import scraper.search_engine as se
+    importlib.reload(se)
+    # replace heavy dependencies with stubs
+    monkeypatch.setattr(se, "FreshRSSManager", lambda: None)
+    monkeypatch.setattr(se, "XMLContentParser", lambda: None)
+    monkeypatch.setattr(se, "DiscordNotifier", lambda: None)
+    searcher = se.FederalRegisterSearcher()
+    searcher._store = se.StoreTerms(tmp_path / "terms.json")
+    searcher.search_terms = []
+    return searcher
+
+
+def test_add_search_term(monkeypatch, tmp_path):
+    searcher = create_searcher(tmp_path, monkeypatch)
+
+    assert searcher.add_search_term("alpha") is True
+    assert searcher.get_search_terms() == ["alpha"]
+    # file persisted
+    data = json.loads((tmp_path / "terms.json").read_text())
+    assert data == ["alpha"]
+
+    # duplicate
+    assert searcher.add_search_term("alpha") is False
+    assert searcher.get_search_terms() == ["alpha"]
+
+    # blank value
+    assert searcher.add_search_term("") is False
+    assert searcher.add_search_term("   ") is False
+    assert searcher.add_search_term(None) is False

--- a/tests/test_store_terms.py
+++ b/tests/test_store_terms.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from store_terms import StoreTerms
+
+
+def test_add_and_remove(tmp_path):
+    path = tmp_path / "terms.json"
+    store = StoreTerms(path)
+
+    assert store.load() == []
+
+    # add first term
+    terms = store.add("alpha")
+    assert terms == ["alpha"]
+    assert json.loads(path.read_text()) == ["alpha"]
+
+    # add second term and check sorting
+    terms = store.add("beta")
+    assert terms == ["alpha", "beta"] or terms == ["beta", "alpha"]
+    # load returns sorted
+    assert store.load() == ["alpha", "beta"]
+
+    # adding duplicate does nothing
+    terms = store.add("beta")
+    assert terms == ["alpha", "beta"]
+
+    # remove a term
+    terms = store.remove("alpha")
+    assert terms == ["beta"]
+    assert store.load() == ["beta"]
+
+    # removing missing term keeps list
+    terms = store.remove("missing")
+    assert terms == ["beta"]


### PR DESCRIPTION
## Summary
- add test suite with pytest
- cover StoreTerms add/remove behavior
- cover FederalRegisterSearcher.add_search_term logic
- document running tests in README
- ship basic pytest.ini

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688701fc1ee483209ac3edb20b1a19e6