### PR TITLE
Fix SEC notification missing URLs

### DIFF
--- a/scraper/search_engine.py
+++ b/scraper/search_engine.py
@@ -123,10 +123,11 @@ class FederalRegisterSearcher:
 
                         # Send Discord notification
                         if not rescan:
-                            self.notifier.send_notification(found_terms, item_id)
+                            self.notifier.send_notification(found_terms, url, item_id)
 
                         found_articles.append({
                             'id': item_id,
+                            'url': url,
                             'terms': found_terms
                         })
 


### PR DESCRIPTION
## Summary
- include SEC item URLs in notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887890468608320a6f746be848ec8f1