### PR TITLE
Ensure case-insensitive XML search

### DIFF
--- a/scraper/xml_parser.py
+++ b/scraper/xml_parser.py
@@ -19,9 +19,10 @@ class XMLContentParser:
             return ""
 
     def search_xml_content(self, xml_content, search_terms):
-        """Search for terms in XML content and return found terms"""
+        """Search for terms in XML content and return found terms."""
+        xml_low = (xml_content or "").lower()
         found_terms = []
         for term in search_terms:
-            if term in xml_content:
+            if term.lower() in xml_low:
                 found_terms.append(term)
         return found_terms

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scraper.xml_parser import XMLContentParser
+
+
+def test_search_xml_content_case_insensitive():
+    parser = XMLContentParser()
+    xml_content = "<root><item>Alpha Beta</item></root>"
+    terms = ["alpha", "BETA", "Gamma"]
+    assert parser.search_xml_content(xml_content, terms) == ["alpha", "BETA"]


### PR DESCRIPTION
## Summary
- update `XMLContentParser.search_xml_content` to ignore case
- add new unit test covering XML search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879bd33dc0832088b6b0ab34ca324c