### PR TITLE
Ensure settings test ignores .env

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 def test_guild_id_default(monkeypatch):
     monkeypatch.delenv("GUILD_ID", raising=False)
+    # Prevent loading a real .env which could set GUILD_ID
+    monkeypatch.setattr("dotenv.main.load_dotenv", lambda *a, **kw: None)
     import config.settings as settings
     importlib.reload(settings)
     assert settings.GUILD_ID == 0


### PR DESCRIPTION
## Summary
- patch `test_settings` so real .env files don't affect the result

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887aa0b958883208bf9435e1842279b