### PR TITLE
Fix env patch in settings tests

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 def test_guild_id_default(monkeypatch):
     monkeypatch.delenv("GUILD_ID", raising=False)
     # Prevent loading a real .env which could set GUILD_ID
-    monkeypatch.setattr("dotenv.main.load_dotenv", lambda *a, **kw: None)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **kw: None)
     import config.settings as settings
     importlib.reload(settings)
     assert settings.GUILD_ID == 0


### PR DESCRIPTION
## Summary
- stop `test_guild_id_default` from loading `.env` by patching `dotenv.load_dotenv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889986b28c883209e0d197a20cd8bc3