### PR TITLE
Add 8-K detection and notifications

### DIFF
--- a/scraper/discord_notifier.py
+++ b/scraper/discord_notifier.py
@@ -26,3 +26,23 @@ class DiscordNotifier:
 
         except Exception as e:
             logger.error(f"Error sending Discord notification: {e}")
+
+    def send_8k_notification(self, company, context, url, item_id=None):
+        """Send a Discord notification specifically for 8-K filings."""
+        try:
+            message = f"8-K found for {company}. Context: {context}"
+            if item_id:
+                message += f" (Article ID: {item_id})"
+            message += f"\n{url}"
+
+            webhook = DiscordWebhook(url=self.webhook_url, content=message)
+            response = webhook.execute()
+
+            if response.status_code == 200:
+                logger.info(f"Discord 8-K notification sent for {company}")
+            else:
+                logger.error(
+                    f"Failed to send Discord 8-K notification: {response.status_code}"
+                )
+        except Exception as e:
+            logger.error(f"Error sending 8-K Discord notification: {e}")

--- a/tests/test_discord_notifier.py
+++ b/tests/test_discord_notifier.py
@@ -28,3 +28,27 @@ def test_send_notification(monkeypatch):
     assert 'alpha' in captured['content']
     assert 'http://example.com' in captured['content']
 
+
+def test_send_8k_notification(monkeypatch):
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+    class WebhookStub:
+        def __init__(self, url, content):
+            captured['url'] = url
+            captured['content'] = content
+        def execute(self):
+            return Response()
+
+    monkeypatch.setattr('scraper.discord_notifier.DiscordWebhook', WebhookStub)
+
+    from scraper.discord_notifier import DiscordNotifier
+    notifier = DiscordNotifier('hook')
+    notifier.send_8k_notification('Co', 'context', 'http://example.com', '42')
+
+    assert captured['url'] == 'hook'
+    assert '8-K found for Co' in captured['content']
+    assert 'context' in captured['content']
+


### PR DESCRIPTION
## Summary
- send dedicated Discord notification for 8-K filings
- detect 8-K filings in SEC feed items and notify with company and context
- support extracting company name from item titles
- expand search engine and notifier unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a74162bb083209055f640e3b8f413